### PR TITLE
Fixed flawed logic in AutoForwarding Inspectors

### DIFF
--- a/Inspectors/AutoForwarding.ps1
+++ b/Inspectors/AutoForwarding.ps1
@@ -1,7 +1,7 @@
 function Inspect-AutoForwarding {
-	$externalForwarding = Get-HostedOutboundSpamFilterPolicy | Select-Object autoforwardingmode
+	$externalForwarding = Get-HostedOutboundSpamFilterPolicy
 
-    If ($externalForwarding -eq "On") {
+    If ($externalForwarding.AutoForwardingMode -eq "On") {
 		$rules = Get-TransportRule
 		$flag = $False
 

--- a/Inspectors/Inspect-AZPSAssignment.json
+++ b/Inspectors/Inspect-AZPSAssignment.json
@@ -1,5 +1,5 @@
 {
-	"FindingName": "Azure PowerShell Service Prinicpal Assignment Missing!",
+	"FindingName": "Azure PowerShell Service Principal Assignment Missing!",
 	"Description": "Dangerous default configuration settings were found in the tenant. By default, Azure tenants allow all users to access the Azure Active Directory and Microsoft Graph PowerShell Modules. This allows any authenticated user or guest the ability to abuse Dangerous Default Permissions, as well as enumerate the entire tenant.",
 	"Remediation": "These permissions can be mitigated by creating and assigning Service Principals for the applications using the instructions in the linked blog post.",
 	"Impact": "Critical",

--- a/Inspectors/Inspect-AZPSAssignment.ps1
+++ b/Inspectors/Inspect-AZPSAssignment.ps1
@@ -15,7 +15,7 @@
 Function Inspect-AZPSAssignment {
     $appIds = @("1b730954-1685-4b74-9bfd-dac224a7b894","14d82eec-204b-4c2f-b7e8-296a70dab67e")
 
-    $void = "No Service Prinicpals Found!"
+    $void = "No Service Principals Found!"
 
     $aad = $false
 

--- a/Inspectors/Inspect-AZPSModules.json
+++ b/Inspectors/Inspect-AZPSModules.json
@@ -1,5 +1,5 @@
 {
-	"FindingName": "Azure PowerShell Service Prinicpal Configuration Missing!",
+	"FindingName": "Azure PowerShell Service Principal Configuration Missing!",
 	"Description": "Dangerous default configuration settings were found in the tenant. By default, Azure tenants allow all users to access the Azure Active Directory and Microsoft Graph PowerShell Modules. This allows any authenticated user or guest the ability to abuse Dangerous Default Permissions, as well as enumerate the entire tenant.",
 	"Remediation": "These permissions can be mitigated by creating and assigning Service Principals for the applications using the instructions in the linked blog post.",
 	"Impact": "Critical",

--- a/Inspectors/Inspect-AZPSModules.ps1
+++ b/Inspectors/Inspect-AZPSModules.ps1
@@ -15,7 +15,7 @@
 Function Inspect-AZPSModules {
     $appIds = @("1b730954-1685-4b74-9bfd-dac224a7b894","14d82eec-204b-4c2f-b7e8-296a70dab67e")
 
-    $void = "No Service Prinicpals Found!"
+    $void = "No Service Principals Found!"
 
     $aad = $false
 

--- a/Inspectors/Inspect-ExternalForwarding.ps1
+++ b/Inspectors/Inspect-ExternalForwarding.ps1
@@ -1,10 +1,10 @@
 function Inspect-ExternalForwarding {
-    $externalForwarding = Get-HostedOutboundSpamFilterPolicy | Select-Object autoforwardingmode
+    $externalForwarding = Get-HostedOutboundSpamFilterPolicy
 
-    If (!$externalForwarding -eq "On") {
-        Return $null
+    If ($externalForwarding.AutoForwardingMode -eq "On") {
+        Return @($org_name)
         }
-	Return @($org_name)
+	Return $null
     }
 
 return Inspect-ExternalForwarding

--- a/Inspectors/MSCommonAttachmentTypesFilter.ps1
+++ b/Inspectors/MSCommonAttachmentTypesFilter.ps1
@@ -2,23 +2,37 @@ function Inspect-MSCommonAttachmentTypesFilter {
 	# These file types are from Microsoft's default definition of the common attachment types filter.
 	$common_file_types = @("ace", "ani", "app", "docm", "exe", "jar", "reg", "scr", "vbe", "vbs")
 	$unfiltered_file_types = @()
-	$malware_filters = Get-MalwareFilterPolicy | Where-Object -FilterScript {!$_.EnableFileFilter}
+	$malware_filters = Get-MalwareFilterPolicy
 
-	ForEach ($common_file_type in $common_file_types) {
-		$file_type_filtered = $false
-		ForEach ($filter in $malware_filters) {
-			If ($filter.FileTypes -contains $common_file_type) {
-				$file_type_filtered = $true
-			}
+	If ($malware_filters.count -gt 1){
+        ForEach ($filter in $malware_filters) {
+            ForEach ($common_file_type in $common_file_types) {
+                If (($filter.FileTypes -notcontains $common_file_type) -and ($filter.EnableFileFilter -eq $true)) {
+                    $unfiltered_file_types += $common_file_type
+					$name = $filter.name
+                }
+            }
+        }
+		if ($unfiltered_file_types.count -gt 0){
+			return "FileTypes not filtered: $unfiltered_file_types, Filter name: $name"
 		}
-		If (-NOT $file_type_filtered) {
-			$unfiltered_file_types += $common_file_type
+		Else {
+			Return $null
 		}
-	}
-	
-	If ($unfiltered_file_types.Count -NE 0) {
-		return $unfiltered_file_types
-	}
+    }
+    Else {
+        If ($malware_filters.EnableFileFilter -eq $false) {
+            Return $malware_filters.Name
+            }
+        Else {
+            ForEach ($common_file_type in $common_file_types) {
+                If ($malware_filters.FileTypes -notcontains $common_file_type) {
+                    $unfiltered_file_types += $common_file_type
+                }
+            }
+            return $unfiltered_file_types
+        }
+    }
 	
 	return $null
 }


### PR DESCRIPTION
Rules for autoforwarding detection via Get-HostedOutboundSpamFilterPolicy were not properly parsing the results causing false positive findings