### PR TITLE
Update 365Inspect.ps1

### DIFF
--- a/365Inspect.ps1
+++ b/365Inspect.ps1
@@ -72,6 +72,8 @@ Function Connect-Services{
 		Connect-MSGraph
 		Write-Output "Connecting to Microsoft Graph"
 		Connect-MgGraph -Scopes "AuditLog.Read.All","Policy.Read.All","Directory.Read.All","IdentityProvider.Read.All","Organization.Read.All","Securityevents.Read.All","ThreatIndicators.Read.All","SecurityActions.Read.All","User.Read.All","UserAuthenticationMethod.Read.All","MailboxSettings.Read"
+    		Write-Output "Connecting to IPPSSession..."
+        Connect-IPPSSession
     }
 }
 


### PR DESCRIPTION
Added the IPPSSession of Exchange Online Management to add auditable inspectors for the module. This module must be additionally called to make use of the Security & Compliance Center.