### PR TITLE
Fix invalid $member property in Inspect-ProperAdminCount

### DIFF
--- a/Inspectors/Inspect-ProperAdminCount.ps1
+++ b/Inspectors/Inspect-ProperAdminCount.ps1
@@ -18,11 +18,11 @@ function Inspect-ProperAdminCount {
             foreach ($member in $gaRoleMembers) {
                 $user = (Invoke-GraphRequest -Method Get -Uri "https://$(@($global:graphURI))/beta/directoryObjects/$($member.principalId)")
                 $info = [PSCustomObject]@{
-                    Name       = ($user.displayName)
-                    UPN        = ($user.userPrincipalName)
-                    Assigned   = $($member.assignmentstate) 
-                    MemberType = $($member.MemberType)
-                    Role       = ($gaRole).DisplayName
+                    Name       = $user.displayName
+                    UPN        = $user.userPrincipalName
+                    Assigned   = $member.assignmentstate
+                    MemberType = $member.MemberType
+                    Role       = $gaRole.DisplayName
                 }
 
                 $results += "User: $($info.Name) - $($info.UPN), Assignment State: $($info.Assigned), Assignment Type: $($info.MemberType)"
@@ -46,12 +46,12 @@ function Inspect-ProperAdminCount {
                 foreach ($member in $gaRoleMembers) {
                     $user = (Invoke-GraphRequest -Method Get -Uri "https://$(@($global:graphURI))/beta/directoryObjects/$($member.id)")
                     $info = [PSCustomObject]@{
-                        Name     = ($member.displayName)
-                        UPN      = ($member.userPrincipalName)
-                        IsSynced = ([bool]$member.onPremisesSyncEnabled)
+                        Name     = $member.displayName
+                        UPN      = $member.userPrincipalName
+                        IsSynced = [bool]$member.onPremisesSyncEnabled
                     }
 
-                    $results += "User: $($info.Name) - $($info.UPN), IsOn-Premise - $($info.IsSynced)"
+                    $results += "User: $($info.Name) - $($info.UPN), Is On-Premise: $($info.IsSynced)"
                 }
 
                 $num_global_admins = ($results | Measure-Object).Count

--- a/Inspectors/Inspect-ProperAdminCount.ps1
+++ b/Inspectors/Inspect-ProperAdminCount.ps1
@@ -9,9 +9,9 @@ function Inspect-ProperAdminCount {
         $license = (Invoke-GraphRequest -Method Get -Uri "https://$(@($global:graphURI))/beta/subscribedSkus").Value.ServicePlans | Where-Object { $_.ServicePlanName -eq 'AAD_PREMIUM_P2' }
 
         If ($license) {
-            $gaRole = (Invoke-GraphRequest  -Method Get -Uri "https://$(@($global:graphURI))/beta/roleManagement/directory/roleDefinitions?filter=displayName eq 'Global Administrator'").Value
+            $gaRole = (Invoke-GraphRequest -Method Get -Uri "https://$(@($global:graphURI))/beta/roleManagement/directory/roleDefinitions?filter=displayName eq 'Global Administrator'").Value
 
-            $gaRoleMembers = (Invoke-GraphRequest  -Method Get -Uri "https://$(@($global:graphURI))/beta/roleManagement/directory/roleAssignments?filter=roleDefinitionId eq '$(($gaRole).templateId)'").Value
+            $gaRoleMembers = (Invoke-GraphRequest -Method Get -Uri "https://$(@($global:graphURI))/beta/roleManagement/directory/roleAssignments?filter=roleDefinitionId eq '$(($gaRole).templateId)'").Value
 
             $results = @()
 
@@ -38,17 +38,17 @@ function Inspect-ProperAdminCount {
             $tenantLicense = ((Invoke-GraphRequest -method get -uri "https://$(@($global:graphURI))/beta/subscribedSkus").Value).ServicePlans
     
             If ($tenantLicense.ServicePlanName -match "AAD_PREMIUM*") {   
-                $gaRole = (Invoke-GraphRequest  -Method Get -Uri "https://$(@($global:graphURI))/beta/directoryRoles?filter=displayName eq 'Global Administrator'").Value
-                $gaRoleMembers = (Invoke-GraphRequest  -Method Get -Uri "https://$(@($global:graphURI))/beta/directoryRoles/$(($gaRole).Id)/members").Value
+                $gaRole = (Invoke-GraphRequest -Method Get -Uri "https://$(@($global:graphURI))/beta/directoryRoles?filter=displayName eq 'Global Administrator'").Value
+                $gaRoleMembers = (Invoke-GraphRequest -Method Get -Uri "https://$(@($global:graphURI))/beta/directoryRoles/$(($gaRole).Id)/members").Value
 
                 $results = @()
 
                 foreach ($member in $gaRoleMembers) {
-                    $user = (Invoke-GraphRequest -Method Get -Uri "https://$(@($global:graphURI))/beta/directoryObjects/$($member.principalId)")
+                    $user = (Invoke-GraphRequest -Method Get -Uri "https://$(@($global:graphURI))/beta/directoryObjects/$($member.id)")
                     $info = [PSCustomObject]@{
                         Name     = ($member.displayName)
                         UPN      = ($member.userPrincipalName)
-                        IsSynced = ($member.onPremisesSyncEnabled)
+                        IsSynced = ([bool]$member.onPremisesSyncEnabled)
                     }
 
                     $results += "User: $($info.Name) - $($info.UPN), IsOn-Premise - $($info.IsSynced)"


### PR DESCRIPTION
If the tenant license is not AAD_PREMIUM_P2 you are calling a different endpoint to get the `$agRoleMembers`

`$gaRoleMembers = (Invoke-GraphRequest -Method Get -Uri "https://$(@($global:graphURI))/beta/directoryRoles/$(($gaRole).Id)/members").Value`

This endpoint returns the members themselves. the correct property to then retrieve the full user properties is `$member.id`, not `$member.principalId`

Additionally `$member.onPremisesSyncEnabled` is null if they are not synced, so the result string is empty. We can cast as a bool so it will display false instead.

Lastly, I cleaned up unnecessary parentheses in the PSCustomObjects