### PR TITLE
Fixed wrong $environment variable check while connecting to security and compliance center

### DIFF
--- a/365Inspect.ps1
+++ b/365Inspect.ps1
@@ -124,7 +124,7 @@ Function Connect-Services {
         Try {
             Write-Output "Connecting to Security and Compliance Center"
 
-            If ($environment -eq 'Default') {
+            If ($environment -eq 'Global') {
                 Connect-IPPSSession -UserPrincipalName $UserPrincipalName
             }
             Else {


### PR DESCRIPTION
Checking value as "default", the main function (line 128) would never be used.